### PR TITLE
#5: Add support for configuring from Consul.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,12 @@ dependencies {
   compile('org.springframework.boot:spring-boot-starter-log4j2')
 	compile('de.codecentric:spring-boot-admin-starter-server')
 	compile('org.springframework.cloud:spring-cloud-starter-consul-discovery')
+	compile('org.springframework.cloud:spring-cloud-starter-consul-config')
   compile('com.fasterxml.jackson.core:jackson-databind')
 	compile('com.fasterxml.jackson.dataformat:jackson-dataformat-yaml')
 	compile('com.fasterxml.jackson.core:jackson-annotations')
+  compile('org.springframework.retry:spring-retry')
+  compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: '2.0.5.RELEASE'
 	runtime('org.springframework.boot:spring-boot-devtools')
   errorprone 'com.google.errorprone:error_prone_core:2.2.0'
 	compileOnly('org.projectlombok:lombok')

--- a/src/main/java/com/ao/avc/AvcApplication.java
+++ b/src/main/java/com/ao/avc/AvcApplication.java
@@ -11,14 +11,18 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+import org.springframework.retry.annotation.EnableRetry;
 
 @EnableDiscoveryClient
 @Configuration
+@EnableRetry
+@EnableAutoConfiguration
 @SpringBootApplication(exclude = {SolrAutoConfiguration.class})
 public class AvcApplication extends AbstractMongoConfiguration {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,18 @@ management.address: 127.0.0.1
 spring.application.name=Avc
 # Spring Profile
 spring.profiles.active=dev
+# Consul Setup
+spring.cloud.consul.host=localhost
+spring.cloud.consul.port=8500
+spring.cloud.consul.discovery.enabled=true
+spring.cloud.consul.discovery.register=true
 spring.cloud.consul.discovery.preferIpAddress=false
+spring.cloud.consul.discovery.healthCheckPath=${management.context-path}/health
+spring.cloud.consul.discovery.healthCheckInterval=15s
+spring.cloud.consul.config.enabled=true
+spring.cloud.consul.config.prefix=configuration
+spring.cloud.consul.config.defaultContext=apps
+spring.cloud.consul.config.profileSeparator='::'
 # Asset File Upload Limits
 spring.http.multipart.max-file-size=128MB
 spring.http.multipart.max-request-size=128MB


### PR DESCRIPTION
Add support for configuring Kelona from Consul.  This uses Spring Cloud Consul (https://cloud.spring.io/spring-cloud-consul/) to enable the config, as well as Spring Retry to handle potential delays in Consul startup.